### PR TITLE
fix unicode encode error on `quilt ls` and `quilt inspect` on Python 2.7

### DIFF
--- a/quilt/tools/command.py
+++ b/quilt/tools/command.py
@@ -30,7 +30,7 @@ from tqdm import tqdm
 from .build import (build_package, build_package_from_contents, generate_build_file,
                     generate_contents, BuildException)
 from .const import DEFAULT_BUILDFILE, LATEST_TAG
-from .core import (hash_contents, find_object_hashes, PackageFormat, TableNode, FileNode,
+from .core import (hash_contents, find_object_hashes, GroupNode, PackageFormat, TableNode, FileNode,
                    decode_node, encode_node, exec_yaml_python, CommandException, diff_dataframes)
 from .hashing import digest_file
 from .store import PackageStore, parse_package

--- a/quilt/tools/command.py
+++ b/quilt/tools/command.py
@@ -866,7 +866,7 @@ def ls():                       # pylint:disable=C0103
         packages = PackageStore(pkg_dir).ls_packages()
         for idx, (owner, pkg) in enumerate(packages):
             prefix = u"└── " if idx == len(packages) - 1 else u"├── "
-            print("%s%s/%s" % (prefix, owner, pkg))
+            print(("%s%s/%s" % (prefix, owner, pkg)).encode('utf-8'))
 
 def inspect(package):
     """


### PR DESCRIPTION
For python 2.7, you will get a unicode encode error like this
```
Traceback (most recent call last):
  File "/usr/local/bin/quilt", line 11, in <module>
    load_entry_point('quilt==2.7.0', 'console_scripts', 'quilt')()
  File "/usr/local/lib/python2.7/dist-packages/quilt/tools/main.py", line 138, in main
    func(**kwargs)
  File "/usr/local/lib/python2.7/dist-packages/quilt/tools/command.py", line 799, in ls
    print("%s%s/%s" % (unicode(prefix), owner, pkg))
UnicodeEncodeError: 'ascii' codec can't encode characters in position 0-2: ordinal not in range(128)
```
because print can't handle a unicode

simplest repro:
```py
prefix = u"└── "
print prefix
# vs
print prefix.encode('utf-8')
```