### PR TITLE
Adding basic support for build in pyspark

### DIFF
--- a/quilt/tools/build.py
+++ b/quilt/tools/build.py
@@ -11,9 +11,10 @@ from six import iteritems
 import yaml
 from tqdm import tqdm
 
-from .store import PackageStore, VALID_NAME_RE, StoreException
 from .const import DEFAULT_BUILDFILE, PACKAGE_DIR_NAME, PARSERS, RESERVED
 from .core import PackageFormat, BuildException, exec_yaml_python
+from .package import Package, ParquetLib
+from .store import PackageStore, VALID_NAME_RE, StoreException
 from .util import FileWithReadProgress
 
 from . import check_functions as qc            # pylint:disable=W0611
@@ -92,8 +93,11 @@ def _build_node(build_dir, package, name, node, fmt, target='pandas', checks_con
 
             print("Serializing %s..." % path)
             try:
-                import pyspark  # pylint:disable=W0612
-                have_pyspark = True
+                if Package.get_parquet_lib() is ParquetLib.SPARK:
+                    import pyspark  # pylint:disable=W0612
+                    have_pyspark = True
+                else:
+                    have_pyspark = False
             except ImportError:
                 have_pyspark = False
 
@@ -113,7 +117,7 @@ def _build_node(build_dir, package, name, node, fmt, target='pandas', checks_con
                 package.save_df(dataframe, name, rel_path, transform, target, fmt)
 
 def _file_to_spark_data_frame(ext, path, target, user_kwargs):
-    from pyspark import SparkContext, sql as sparksql
+    from pyspark import sql as sparksql
     _ = target  # TODO: why is this unused?
     ext = ext.lower() # ensure that case doesn't matter
     logic = PARSERS.get(ext)

--- a/quilt/tools/package.py
+++ b/quilt/tools/package.py
@@ -156,7 +156,8 @@ class Package(object):
         if enumformat is PackageFormat.PARQUET:
             # switch parquet lib
             parqlib = self.get_parquet_lib()
-            if parqlib is ParquetLib.ARROW:
+            if isinstance(dataframe, pd.DataFrame):
+                #parqlib is ParquetLib.ARROW: # other parquet libs are deprecated, remove?
                 import pyarrow as pa
                 from pyarrow import parquet
                 table = pa.Table.from_pandas(dataframe)


### PR DESCRIPTION
Adding a rough implementation of quilt build for pyspark. Read CSV/TSV
is supported without pandas-specific parsing options.