### PR TITLE
Improve S3 error reporting

### DIFF
--- a/quilt/tools/command.py
+++ b/quilt/tools/command.py
@@ -490,8 +490,11 @@ def push(package, public=False, reupload=False):
                         with lock:
                             uploaded.append(obj_hash)
                     except requests.exceptions.RequestException as ex:
+                        message = "Upload failed for %s:\nURL: %s\nStatus code: %s\nResponse: %r\n" % (
+                            obj_hash, ex.request.url, ex.response.status_code, ex.response.text
+                        )
                         with lock:
-                            tqdm.write("Upload failed for %s: error %s" % (obj_hash, ex))
+                            tqdm.write(message)
 
         threads = [
             Thread(target=_worker_thread, name="upload-worker-%d" % i)
@@ -737,8 +740,10 @@ def install(package, hash=None, version=None, tag=None, force=False):
 
             response = s3_session.get(url, stream=True)
             if not response.ok:
-                msg = "Download {hash} failed: error {code}"
-                raise CommandException(msg.format(hash=download_hash, code=response.status_code))
+                message = "Download failed for %s:\nURL: %s\nStatus code: %s\nResponse: %r\n" % (
+                    download_hash, response.request.url, response.status_code, response.text
+                )
+                raise CommandException(message)
 
             length_remaining = response.raw.length_remaining
 


### PR DESCRIPTION
Print out the full body of the error message to make debugging possible.