### PR TITLE
Disable pyopenssl.

### DIFF
--- a/quilt/tools/command.py
+++ b/quilt/tools/command.py
@@ -40,6 +40,17 @@ from . import check_functions as qc
 
 from .. import nodes
 
+# pyOpenSSL and S3 don't play well together. pyOpenSSL is completely optional, but gets enabled by requests.
+# So... We disable it. That's what boto does.
+# https://github.com/boto/botocore/issues/760
+# https://github.com/boto/botocore/pull/803
+try:
+    from urllib3.contrib import pyopenssl
+    pyopenssl.extract_from_urllib3()
+except ImportError:
+    pass
+
+
 DEFAULT_QUILT_PKG_URL = 'https://pkg.quiltdata.com'
 QUILT_PKG_URL = os.environ.get('QUILT_PKG_URL', DEFAULT_QUILT_PKG_URL)
 GIT_URL_RE = re.compile(r'(?P<url>http[s]?://[\w./~_-]+\.git)(?:@(?P<branch>[\w_-]+))?')

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,7 @@ setup(
         'packaging>=16.8',
         'pandas>=0.19.2',
         'pyarrow>=0.4.0',
+        'pyOpenSSL>=16.2.0',  # Note: not actually used at the moment.
         'pyyaml>=3.12',
         'requests>=2.12.4',
         'responses>=0.5.1,<0.6.1',  # 0.6.1 is broken, but already fixed in master

--- a/setup.py
+++ b/setup.py
@@ -36,11 +36,11 @@ setup(
     keywords='quilt quiltdata shareable data dataframe package platform pandas',
     install_requires=[
         'appdirs>=1.4.0',
+        'enum34; python_version<"3.4"',
         'future>=0.16.0',
         'packaging>=16.8',
         'pandas>=0.19.2',
         'pyarrow>=0.4.0',
-        'pyOpenSSL>=16.2.0',
         'pyyaml>=3.12',
         'requests>=2.12.4',
         'responses>=0.5.1,<0.6.1',  # 0.6.1 is broken, but already fixed in master


### PR DESCRIPTION
It's not needed, but causes problems with S3. boto disables it, so we should too.