### PR TITLE
`find()` fails on YAML sequences

### DIFF
--- a/quilt/test/build.yml
+++ b/quilt/test/build.yml
@@ -7,5 +7,8 @@ contents:
       file: data/10KRows13Cols.tsv
     xls:
       file: data/10KRows13Cols.xlsx
+    xls_skip:
+      skiprows: [0,10,100]
+      file: data/10KRows13Cols.xlsx
   README:
     file: data/README.md

--- a/quilt/test/test_import.py
+++ b/quilt/test/test_import.py
@@ -35,9 +35,9 @@ class ImportTest(QuiltTestCase):
         assert package.dataframes == dataframes
         assert package.README == README
 
-        assert set(dataframes._keys()) == {'xls', 'csv', 'tsv'}
+        assert set(dataframes._keys()) == {'xls', 'csv', 'tsv', 'xls_skip'}
         assert set(dataframes._group_keys()) == set()
-        assert set(dataframes._data_keys()) == {'xls', 'csv', 'tsv'}
+        assert set(dataframes._data_keys()) == {'xls', 'csv', 'tsv', 'xls_skip'}
 
         assert isinstance(README(), string_types)
         assert isinstance(README._data(), string_types)

--- a/quilt/tools/build.py
+++ b/quilt/tools/build.py
@@ -203,17 +203,17 @@ def build_package(username, package, yaml_path, checks_path=None, dry_run=False,
         only descend iterables
         """
         if(isinstance(value, Iterable)):
-          for k, v in iteritems(value):
-              if k == key:
-                  yield v
-              elif isinstance(v, dict):
-                  for result in find(key, v):
-                      yield result
-              elif isinstance(v, list):
-                  for item in v:
-                      for result in find(key, item):
-                          yield result
-      
+            for k, v in iteritems(value):
+                if k == key:
+                    yield v
+                elif isinstance(v, dict):
+                    for result in find(key, v):
+                        yield result
+                elif isinstance(v, list):
+                    for item in v:
+                        for result in find(key, item):
+                            yield result
+        
     build_data = load_yaml(yaml_path)
     # default to 'checks.yml' if build.yml contents: contains checks, but
     # there's no inlined checks: defined by build.yml

--- a/quilt/tools/build.py
+++ b/quilt/tools/build.py
@@ -202,7 +202,7 @@ def build_package(username, package, yaml_path, checks_path=None, dry_run=False,
         find matching nodes recursively;
         only descend iterables
         """
-        if(isinstance(value, Iterable)):
+        if isinstance(value, Iterable):
             for k, v in iteritems(value):
                 if k == key:
                     yield v

--- a/quilt/tools/build.py
+++ b/quilt/tools/build.py
@@ -1,7 +1,7 @@
 """
 parse build file, serialize package
 """
-from collections import defaultdict
+from collections import defaultdict, Iterable
 import importlib
 from types import ModuleType
 import os
@@ -198,22 +198,22 @@ def build_package(username, package, yaml_path, checks_path=None, dry_run=False,
     Returns the name of the package.
     """
     def find(key, value):
-        """find all nodes transitively"""
-        try:
-            vals = iteritems(value)
-            for k, v in vals:
-                if k == key:
-                    yield v
-                elif isinstance(v, dict):
-                    for result in find(key, v):
-                        yield result
-                elif isinstance(v, list):
-                    for item in v:
-                        for result in find(key, item):
-                            yield result
-        except AttributeError:
-            yield None
-        
+        """
+        find matching nodes recursively;
+        only descend iterables
+        """
+        if(isinstance(value, Iterable)):
+          for k, v in iteritems(value):
+              if k == key:
+                  yield v
+              elif isinstance(v, dict):
+                  for result in find(key, v):
+                      yield result
+              elif isinstance(v, list):
+                  for item in v:
+                      for result in find(key, item):
+                          yield result
+      
     build_data = load_yaml(yaml_path)
     # default to 'checks.yml' if build.yml contents: contains checks, but
     # there's no inlined checks: defined by build.yml

--- a/quilt/tools/build.py
+++ b/quilt/tools/build.py
@@ -198,16 +198,20 @@ def build_package(username, package, yaml_path, checks_path=None, dry_run=False,
     """
     def find(key, value):
         """find all nodes transitively"""
-        for k, v in iteritems(value):
-            if k == key:
-                yield v
-            elif isinstance(v, dict):
-                for result in find(key, v):
-                    yield result
-            elif isinstance(v, list):
-                for item in v:
-                    for result in find(key, item):
+        try:
+            vals = iteritems(value)
+            for k, v in vals:
+                if k == key:
+                    yield v
+                elif isinstance(v, dict):
+                    for result in find(key, v):
                         yield result
+                elif isinstance(v, list):
+                    for item in v:
+                        for result in find(key, item):
+                            yield result
+        except AttributeError:
+            yield None
         
     build_data = load_yaml(yaml_path)
     # default to 'checks.yml' if build.yml contents: contains checks, but


### PR DESCRIPTION
Some pandas args take lists  (sequences in YAML). `build.py:find` did not work for this case; it would descend the children of the sequence and then blow up because, e.g. in test case below, the children (ints) are not iterable.

```
subgroup:
   # transform and skiprows apply to all children, unless overidden
   transform: tsv
   skiprows: [0,5,20]
```