### PR TITLE
Factor out common test logic

### DIFF
--- a/quilt/test/build.yml
+++ b/quilt/test/build.yml
@@ -7,5 +7,8 @@ contents:
       file: data/10KRows13Cols.tsv
     xls:
       file: data/10KRows13Cols.xlsx
+    xls_skip:
+      skiprows: 3
+      file: data/10KRows13Cols.xlsx
   README:
     file: data/README.md

--- a/quilt/test/test_build.py
+++ b/quilt/test/test_build.py
@@ -14,22 +14,6 @@ from .utils import QuiltTestCase
 
 PACKAGE = 'groot'
 
-# shared testing logic between pyarrow and default env
-def _test_dataframes(dataframes):
-  csv = dataframes.csv()
-  tsv = dataframes.csv()
-  xls = dataframes.xls()
-  xls_skip = dataframes.xls_skip()
-  rows = len(csv.index)
-  assert rows == len(tsv.index) and rows == len(xls.index), \
-      'Expected dataframes to have same # rows'
-  cols = len(csv.columns)
-  assert cols == len(tsv.columns) and cols == len(xls.columns), \
-      'Expected dataframes to have same # columns'
-  assert xls_skip.shape == (9997, 13), \
-      'Expected 9,997 Rows and 13 Columns'
-  # TODO add more integrity checks, incl. negative test cases
-
 class BuildTest(QuiltTestCase):
 
     def test_build_parquet_default(self):
@@ -44,7 +28,7 @@ class BuildTest(QuiltTestCase):
         # not hardcoded vals (this will require loading modules from variable
         # names, probably using __module__)
         from quilt.data.test_parquet.groot import dataframes, README
-        _test_dataframes(dataframes)
+        self._test_dataframes(dataframes)
         assert os.path.exists(README())
 
     def test_build_parquet_pyarrow(self):
@@ -57,10 +41,26 @@ class BuildTest(QuiltTestCase):
         path = os.path.join(mydir, './build.yml')
         build.build_package('test_arrow', PACKAGE, path)
         from quilt.data.test_arrow.groot import dataframes, README
-        _test_dataframes(dataframes)
+        self._test_dataframes(dataframes)
         assert os.path.exists(README())
         assert Package.get_parquet_lib() is ParquetLib.ARROW
         del os.environ["QUILT_PARQUET_LIBRARY"]
+
+    # shared testing logic between pyarrow and default env
+    def _test_dataframes(self, dataframes):
+        csv = dataframes.csv()
+        tsv = dataframes.csv()
+        xls = dataframes.xls()
+        xls_skip = dataframes.xls_skip()
+        rows = len(csv.index)
+        assert rows == len(tsv.index) and rows == len(xls.index), \
+            'Expected dataframes to have same # rows'
+        cols = len(csv.columns)
+        assert cols == len(tsv.columns) and cols == len(xls.columns), \
+            'Expected dataframes to have same # columns'
+        assert xls_skip.shape == (9997, 13), \
+            'Expected 9,997 Rows and 13 Columns'
+        # TODO add more integrity checks, incl. negative test cases
 
     def test_build_hdf5(self):
         mydir = os.path.dirname(__file__)

--- a/quilt/test/test_build.py
+++ b/quilt/test/test_build.py
@@ -12,10 +12,26 @@ from ..tools.package import ParquetLib, Package
 from ..tools import build, command
 from .utils import QuiltTestCase
 
-
 PACKAGE = 'groot'
 
+# shared testing logic between pyarrow and default env
+def _test_dataframes(dataframes):
+  csv = dataframes.csv()
+  tsv = dataframes.csv()
+  xls = dataframes.xls()
+  xls_skip = dataframes.xls_skip()
+  rows = len(csv.index)
+  assert rows == len(tsv.index) and rows == len(xls.index), \
+      'Expected dataframes to have same # rows'
+  cols = len(csv.columns)
+  assert cols == len(tsv.columns) and cols == len(xls.columns), \
+      'Expected dataframes to have same # columns'
+  assert xls_skip.shape == (9997, 13), \
+      'Expected 9,997 Rows and 13 Columns'
+  # TODO add more integrity checks, incl. negative test cases
+
 class BuildTest(QuiltTestCase):
+
     def test_build_parquet_default(self):
         """
         Test compilation to Parquet via the default library
@@ -28,18 +44,8 @@ class BuildTest(QuiltTestCase):
         # not hardcoded vals (this will require loading modules from variable
         # names, probably using __module__)
         from quilt.data.test_parquet.groot import dataframes, README
-        csv = dataframes.csv()
-        tsv = dataframes.csv()
-        xls = dataframes.xls()
-        rows = len(csv.index)
-        assert rows == len(tsv.index) and rows == len(xls.index), \
-            'Expected dataframes to have same # rows'
+        _test_dataframes(dataframes)
         assert os.path.exists(README())
-        cols = len(csv.columns)
-        print(csv.columns, xls.columns, tsv.columns)
-        assert cols == len(tsv.columns) and cols == len(xls.columns), \
-            'Expected dataframes to have same # columns'
-        # TODO add more integrity checks, incl. negative test cases
 
     def test_build_parquet_pyarrow(self):
         """
@@ -50,22 +56,9 @@ class BuildTest(QuiltTestCase):
         mydir = os.path.dirname(__file__)
         path = os.path.join(mydir, './build.yml')
         build.build_package('test_arrow', PACKAGE, path)
-        # TODO load DFs based on contents of .yml file at path
-        # not hardcoded vals (this will require loading modules from variable
-        # names, probably using __module__)
         from quilt.data.test_arrow.groot import dataframes, README
-        csv = dataframes.csv()
-        tsv = dataframes.csv()
-        xls = dataframes.xls()
-        rows = len(csv.index)
-        assert rows == len(tsv.index) and rows == len(xls.index), \
-            'Expected dataframes to have same # rows'
-        cols = len(csv.columns)
-        print(csv.columns, xls.columns, tsv.columns)
-        assert cols == len(tsv.columns) and cols == len(xls.columns), \
-            'Expected dataframes to have same # columns'
+        _test_dataframes(dataframes)
         assert os.path.exists(README())
-        # TODO add more integrity checks, incl. negative test cases
         assert Package.get_parquet_lib() is ParquetLib.ARROW
         del os.environ["QUILT_PARQUET_LIBRARY"]
 

--- a/quilt/test/test_import.py
+++ b/quilt/test/test_import.py
@@ -35,9 +35,9 @@ class ImportTest(QuiltTestCase):
         assert package.dataframes == dataframes
         assert package.README == README
 
-        assert set(dataframes._keys()) == {'xls', 'csv', 'tsv'}
+        assert set(dataframes._keys()) == {'xls', 'csv', 'tsv', 'xls_skip'}
         assert set(dataframes._group_keys()) == set()
-        assert set(dataframes._data_keys()) == {'xls', 'csv', 'tsv'}
+        assert set(dataframes._data_keys()) == {'xls', 'csv', 'tsv', 'xls_skip'}
 
         assert isinstance(README(), string_types)
         assert isinstance(README._data(), string_types)


### PR DESCRIPTION
Not sure if defining utility functions outside of the BuildTest class is best practice. In any case, repeated test logic should be in one place so it's not fragile.