### PR TITLE
Quick fix to quilt install

### DIFF
--- a/quilt/tools/command.py
+++ b/quilt/tools/command.py
@@ -753,7 +753,7 @@ def install_via_requirements(requirements_str, force=False):
             package += '/' + subpath
         install(package, hash, version, tag, force=force)
     
-def install(package, hash=None, version=None, tag=None, force=False, reqfile=False):
+def install(package, hash=None, version=None, tag=None, force=False):
     """
     Download a Quilt data package from the server and install locally.
 
@@ -769,7 +769,7 @@ def install(package, hash=None, version=None, tag=None, force=False, reqfile=Fal
     if len(package) == 0:
         raise CommandException("package name is empty.")
 
-    if reqfile or package[0] == '@' or '\n' in package:
+    if package[0] == '@' or '\n' in package:
         return install_via_requirements(package, force=force)
         
     assert [hash, version, tag].count(None) == 2

--- a/quilt/tools/command.py
+++ b/quilt/tools/command.py
@@ -753,7 +753,7 @@ def install_via_requirements(requirements_str, force=False):
             package += '/' + subpath
         install(package, hash, version, tag, force=force)
     
-def install(package, hash=None, version=None, tag=None, force=False):
+def install(package, hash=None, version=None, tag=None, force=False, reqfile=False):
     """
     Download a Quilt data package from the server and install locally.
 
@@ -769,7 +769,7 @@ def install(package, hash=None, version=None, tag=None, force=False):
     if len(package) == 0:
         raise CommandException("package name is empty.")
 
-    if package[0] == '@' or '\n' in package:
+    if reqfile or package[0] == '@' or '\n' in package:
         return install_via_requirements(package, force=force)
         
     assert [hash, version, tag].count(None) == 2

--- a/quilt/tools/main.py
+++ b/quilt/tools/main.py
@@ -100,9 +100,6 @@ def main():
     install_p.set_defaults(func=command.install)
     install_p.add_argument("-f", "--force", action="store_true", help="Overwrite without prompting")
     install_group = install_p.add_mutually_exclusive_group()
-    # can also use @filename to load from a file
-    install_group.add_argument("-r", "--requirements-file", action="store_true", dest='reqfile',
-                               help="force treatment of package name as requirements filename")
     install_group.add_argument("-x", "--hash", help="Package hash",
                                type=lambda val: check_hash(install_p, val))
     install_group.add_argument("-v", "--version", type=str, help="Package version")


### PR DESCRIPTION
Quick fix to quilt install so that it can run on the command line again. Adding the reqfile arg to install and including it in the switch to install_via_requirements.