### PR TITLE
Add support for resuming downloads of partially-downloaded fragments

### DIFF
--- a/quilt/test/test_install.py
+++ b/quilt/test/test_install.py
@@ -133,7 +133,7 @@ class InstallTest(QuiltTestCase):
 
         with open(os.path.join(teststore.package_path(user, package),
                                Package.CONTENTS_DIR,
-                               contents_hash), 'rb') as fd:
+                               contents_hash), 'r') as fd:
             file_contents = json.load(fd, object_hook=decode_node)
             assert file_contents == contents
 

--- a/quilt/test/test_install.py
+++ b/quilt/test/test_install.py
@@ -81,11 +81,11 @@ class InstallTest(QuiltTestCase):
             file_contents = json.load(fd, object_hook=decode_node)
             assert file_contents == contents
 
-        with open(os.path.join(self._store_dir, 'objs/{hash}'.format(hash=table_hash)), 'rb') as fd:
+        with open(teststore.object_path(objhash=table_hash), 'rb') as fd:
             contents = fd.read()
             assert contents == table_data
 
-        with open(os.path.join(self._store_dir, 'objs/{hash}'.format(hash=file_hash)), 'rb') as fd:
+        with open(teststore.object_path(objhash=file_hash), 'rb') as fd:
             contents = fd.read()
             assert contents == file_data
 
@@ -137,7 +137,7 @@ class InstallTest(QuiltTestCase):
             file_contents = json.load(fd, object_hook=decode_node)
             assert file_contents == contents
 
-        with open(os.path.join(self._store_dir, 'objs/{hash}'.format(hash=table_hash)), 'rb') as fd:
+        with open(teststore.object_path(objhash=table_hash), 'rb') as fd:
             contents = fd.read()
             assert contents == table_data
 
@@ -307,7 +307,7 @@ packages:
 
         # file1 exists, but has the wrong contents.
         with open(teststore.object_path(objhash=file_hash_list[1]), 'wb') as fd:
-            fd.write("Garbage")
+            fd.write(b"Garbage")
 
         # file2 does not exist.
 

--- a/quilt/tools/command.py
+++ b/quilt/tools/command.py
@@ -6,11 +6,12 @@ Command line parsing and command dispatch
 from __future__ import print_function
 from builtins import input      # pylint:disable=W0622
 from datetime import datetime
+import gzip
 import hashlib
 import json
 import os
 import re
-from shutil import move, rmtree
+from shutil import copyfileobj, move, rmtree
 import stat
 import subprocess
 import sys
@@ -59,6 +60,9 @@ GIT_URL_RE = re.compile(r'(?P<url>http[s]?://[\w./~_-]+\.git)(?:@(?P<branch>[\w_
 CHUNK_SIZE = 4096
 
 PARALLEL_UPLOADS = 20
+
+S3_CONNECT_TIMEOUT = 30
+S3_READ_TIMEOUT = 30
 
 LOG_TIMEOUT = 3  # 3 seconds
 
@@ -884,29 +888,55 @@ def install(package, hash=None, version=None, tag=None, force=False):
                     print("Fragment already installed, but has the wrong hash (%s); re-downloading." %
                         file_hash)
 
-            response = s3_session.get(url, stream=True)
-            if not response.ok:
-                message = "Download failed for %s:\nURL: %s\nStatus code: %s\nResponse: %r\n" % (
-                    download_hash, response.request.url, response.status_code, response.text
+            temp_path_gz = store.temporary_object_path(download_hash + '.gz')
+            with open(temp_path_gz, 'ab') as output_file:
+                starting_length = output_file.tell()
+                response = s3_session.get(
+                    url,
+                    headers={
+                        'Range': 'bytes=%d-' % starting_length
+                    },
+                    stream=True,
+                    timeout=(S3_CONNECT_TIMEOUT, S3_READ_TIMEOUT)
                 )
-                raise CommandException(message)
 
-            length_remaining = response.raw.length_remaining
+                # RANGE_NOT_SATISFIABLE means, we already have the whole file.
+                if response.status_code != requests.codes.RANGE_NOT_SATISFIABLE:
+                    if not response.ok:
+                        message = "Download failed for %s:\nURL: %s\nStatus code: %s\nResponse: %r\n" % (
+                            download_hash, response.request.url, response.status_code, response.text
+                        )
+                        raise CommandException(message)
 
-            temp_path = store.temporary_object_path(download_hash)
-            with open(temp_path, 'wb') as output_file:
-                with tqdm(total=length_remaining, unit='B', unit_scale=True) as progress:
-                    # `requests` will automatically un-gzip the content, as long as
-                    # the 'Content-Encoding: gzip' header is set.
-                    # To report progress, however, we need the length of the original compressed data;
-                    # we use the undocumented but technically public `response.raw.length_remaining`.
-                    for chunk in response.iter_content(chunk_size=CHUNK_SIZE):
-                        if chunk: # filter out keep-alive new chunks
+                    # Fragments have the 'Content-Encoding: gzip' header set to make requests ungzip them
+                    # automatically - but that turned out to be a bad idea because it makes resuming downloads
+                    # impossible.
+                    # HACK: For now, just delete the header. Eventually, update the data in S3.
+                    response.raw.headers.pop('Content-Encoding', None)
+
+                    # Make sure we're getting the expected range.
+                    assert response.headers.get('Content-Range', '').startswith('bytes %d-' % starting_length)
+
+                    length_remaining = response.raw.length_remaining
+                    total_length = starting_length + length_remaining
+
+                    with tqdm(initial=starting_length, total=total_length, unit='B', unit_scale=True) as progress:
+                        for chunk in response.iter_content(CHUNK_SIZE):
                             output_file.write(chunk)
-                        if response.raw.length_remaining is not None:  # Not set in unit tests.
-                            progress.update(length_remaining - response.raw.length_remaining)
-                            length_remaining = response.raw.length_remaining
+                            if response.raw.length_remaining is not None:  # Not set in unit tests.
+                                progress.update(length_remaining - response.raw.length_remaining)
+                                length_remaining = response.raw.length_remaining
 
+            # Ungzip the downloaded fragment.
+            temp_path = store.temporary_object_path(download_hash)
+            try:
+                with gzip.open(temp_path_gz, 'rb') as f_in, open(temp_path, 'wb') as f_out:
+                    copyfileobj(f_in, f_out)
+            finally:
+                # Delete the file unconditionally - in case it's corrupted and cannot be ungzipped.
+                os.remove(temp_path_gz)
+
+            # Check the hash of the result.
             file_hash = digest_file(temp_path)
             if file_hash != download_hash:
                 os.remove(temp_path)


### PR DESCRIPTION
- Use the "Range" header to get partial content
- Ungzip the content manually instead of letting requests do it
- Set connect/read timeouts
- Update the tests to use bytes instead of strings