### PR TITLE
Handle `quilt generate` for empty directories

### DIFF
--- a/quilt/test/test_build.py
+++ b/quilt/test/test_build.py
@@ -85,9 +85,15 @@ class BuildTest(QuiltTestCase):
         build.generate_build_file(path)
         assert os.path.exists(buildfilepath)
 
-        tree = load_yaml(buildfilepath)
-        assert 'empty' not in tree, \
-            "Empty directories should not appear in generated buildfile"
+        build.build_package('test_generated', 'generated', buildfilepath)
+
+        from quilt.data.test_generated import generated
+
+        assert all(k in generated._keys() for k in ['bad', 'foo', 'nuts', 'README']), \
+            'Missing expected keys'
+
+        assert 'empty' not in generated._keys(), \
+            'Empty directories should not appear in generated buildfile'
 
         with pytest.raises(build.BuildException):
             # ensure that quilt generate in an empty directory throws

--- a/quilt/test/test_build.py
+++ b/quilt/test/test_build.py
@@ -9,7 +9,6 @@ import pytest
 from six import assertRaisesRegex, string_types
 import yaml
 
-from ..tools.core import load_yaml
 from .. import nodes
 from ..tools.package import ParquetLib, Package
 from ..tools import build, command

--- a/quilt/test/test_build.py
+++ b/quilt/test/test_build.py
@@ -78,6 +78,9 @@ class BuildTest(QuiltTestCase):
         mydir = os.path.dirname(__file__)
         path = os.path.join(mydir, 'data')
         buildfilepath = os.path.join(path, 'build.yml')
+        empty_dir = os.path.join(path, 'empty')
+        os.makedirs(empty_dir)
+
         assert not os.path.exists(buildfilepath), "%s already exists" % buildfilepath
         build.generate_build_file(path)
         assert os.path.exists(buildfilepath)
@@ -86,13 +89,12 @@ class BuildTest(QuiltTestCase):
         assert 'empty' not in tree, \
             "Empty directories should not appear in generated buildfile"
 
-        empty_dir = os.path.join(path, 'empty')
-        os.makedirs(empty_dir)
         with pytest.raises(build.BuildException):
             # ensure that quilt generate in an empty directory throws
             build.generate_build_file(empty_dir)
-        os.rmdir(empty_dir)
 
+        # clean up files/dirs we created for this test
+        os.rmdir(empty_dir)
         os.remove(buildfilepath)
 
     def test_failover(self):

--- a/quilt/tools/build.py
+++ b/quilt/tools/build.py
@@ -312,13 +312,20 @@ def generate_contents(startpath, outfilename=DEFAULT_BUILDFILE):
             name == outfilename
         )
 
+    def _is_empty_dir(dir_path):
+        return os.path.isdir(dir_path) and not os.listdir(dir_path)
+
     def _generate_contents(dir_path):
         safename_duplicates = defaultdict(list)
-        for name in os.listdir(dir_path):
-            if _ignored_name(name):
-                continue
+        children = os.listdir(dir_path)
+        if not children:
+            raise BuildException("Cannot generate from empty directory: %r" % dir_path)
 
+        for name in children:
             path = os.path.join(dir_path, name)
+
+            if _ignored_name(name) or _is_empty_dir(path):
+                continue
 
             if os.path.isdir(path):
                 nodename = name

--- a/quilt/tools/command.py
+++ b/quilt/tools/command.py
@@ -492,7 +492,7 @@ def build_from_path(package, path, dry_run=False, env='default'):
         if not dry_run:
             print("Built %s/%s successfully." % (owner, pkg))
     except BuildException as ex:
-        raise CommandException("Failed to build the package: %s" % ex)
+        raise CommandException("Build failed: %s" % ex)
 
 def log(package):
     """


### PR DESCRIPTION
I wasn't sure if creating and then deleting the `empty` directory in code was the right thing to do, or if the unit test cleans up after itself (which obviously doesn't work since `build.yml` lingers when the test fails). note that git makes it impossible to check in an empty directory.