### PR TITLE
Unit tests for column types

### DIFF
--- a/quilt/test/build.yml
+++ b/quilt/test/build.yml
@@ -3,6 +3,8 @@ contents:
   dataframes:
     csv: 
       file: data/10KRows13Cols.csv
+    nulls:
+      file: data/nulls.csv
     tsv:
       file: data/10KRows13Cols.tsv
     xls:

--- a/quilt/test/data/nulls.csv
+++ b/quilt/test/data/nulls.csv
@@ -1,0 +1,5 @@
+strings,integers,floats,integers_nulled
+"excellent",7,9.999,1
+"poor",12,,2
+,14,1e19,3
+'',99,3.1415,

--- a/quilt/test/test_build.py
+++ b/quilt/test/test_build.py
@@ -5,6 +5,7 @@ Test the build process
 #the functions that cli calls
 import os
 
+import pandas.api.types as ptypes
 from six import assertRaisesRegex, string_types
 import yaml
 
@@ -61,6 +62,15 @@ class BuildTest(QuiltTestCase):
             'Expected dataframes to have same # columns'
         assert xls_skip.shape == (9997, 13), \
             'Expected 9,997 Rows and 13 Columns'
+        nulls = dataframes.nulls()
+        assert ptypes.is_string_dtype(nulls['strings']), \
+            'Expected column of strings to deserialize as strings'
+        assert ptypes.is_integer_dtype(nulls['integers']), \
+            'Expected column of integers to deserialize as integers'
+        assert ptypes.is_float_dtype(nulls['floats']), \
+            'Expected column of floats to deserialize as floats'
+        assert ptypes.is_numeric_dtype(nulls['integers_nulled']), \
+            'Expected column of ints with nulls to deserialize as numeric'
         # TODO add more integrity checks, incl. negative test cases
 
     def test_build_hdf5(self):

--- a/quilt/test/test_import.py
+++ b/quilt/test/test_import.py
@@ -36,9 +36,9 @@ class ImportTest(QuiltTestCase):
         assert package.dataframes == dataframes
         assert package.README == README
 
-        assert set(dataframes._keys()) == {'xls', 'csv', 'tsv', 'xls_skip'}
+        assert set(dataframes._keys()) == {'xls', 'csv', 'tsv', 'xls_skip', 'nulls'}
         assert set(dataframes._group_keys()) == set()
-        assert set(dataframes._data_keys()) == {'xls', 'csv', 'tsv', 'xls_skip'}
+        assert set(dataframes._data_keys()) == {'xls', 'csv', 'tsv', 'xls_skip', 'nulls'}
 
         assert isinstance(README(), string_types)
         assert isinstance(README._data(), string_types)

--- a/quilt/tools/const.py
+++ b/quilt/tools/const.py
@@ -30,9 +30,8 @@ HASH_TYPE = 'sha256'
 RSA_BITS = 2048
 
 # TODO nan probably not a safe choice and may pollute number cols with strs
-_kwargs = {'keep_default_na': False, 'na_values': ['nan']} # pylint:disable=C0103
+_kwargs = {} # default kwargs pylint:disable=C0103
 # Supported build targets and file types
-# BUILD[target][file_extension]
 # file_extension should be lowercase
 PARSERS = {
     'csv': {


### PR DESCRIPTION
@kevinemoore I changed null parsing a bit. Maybe I broke some of the use cases we used `keep_default_na` and `na_values` for? If so can you add a breaking unit test?