### PR TITLE
Don't remove the no longer existant .json extension

### DIFF
--- a/quilt/nodes.py
+++ b/quilt/nodes.py
@@ -96,7 +96,7 @@ class PackageNode(GroupNode):
     """
 
     def _class_repr(self):
-        finfo = self._package.get_path()[:-len(PackageStore.PACKAGE_FILE_EXT)]
+        finfo = self._package.get_path()
         return "<%s %r>" % (self.__class__.__name__, finfo)
 
     def _set(self, path, value):

--- a/quilt/tools/store.py
+++ b/quilt/tools/store.py
@@ -33,7 +33,6 @@ class PackageStore(object):
     class and its subclasses abstract file formats, file naming and
     reading and writing to/from data files.
     """
-    PACKAGE_FILE_EXT = '.json'
     BUILD_DIR = 'build'
     OBJ_DIR = 'objs'
     TMP_OBJ_DIR = os.path.join('objs', 'tmp')


### PR DESCRIPTION
Now it just causes the package directory name to be truncated.