### PR TITLE
For install command, require `package` arg if default yml not present

### DIFF
--- a/compiler/quilt/tools/main.py
+++ b/compiler/quilt/tools/main.py
@@ -177,8 +177,6 @@ def main():
         return 0
     except command.CommandException as ex:
         print(ex, file=sys.stderr)
-        print()
-        print(subparsers.choices[cmd].format_help())
         return 1
     except requests.exceptions.ConnectionError as ex:
         print("Failed to connect: %s" % ex, file=sys.stderr)

--- a/compiler/quilt/tools/main.py
+++ b/compiler/quilt/tools/main.py
@@ -6,6 +6,7 @@ from __future__ import print_function
 
 import argparse
 import sys
+import os
 import requests
 
 from . import command
@@ -96,8 +97,12 @@ def main():
     tag_remove_p.set_defaults(func=command.tag_remove)
 
     install_p = subparsers.add_parser("install")
-    install_p.add_argument("package", type=str, help="owner/package_name[/path/...] or @filename",
-                           nargs="?", default="@"+DEFAULT_QUILT_YML)
+    if os.path.exists(DEFAULT_QUILT_YML):
+        install_p.add_argument("package", type=str, help="owner/package_name[/path/...] or @filename",
+                               nargs="?", default="@"+DEFAULT_QUILT_YML)
+    else:
+        install_p.add_argument("package", type=str, help="owner/package_name[/path/...] or @filename",
+                               nargs="+")
     install_p.set_defaults(func=command.install)
     install_p.add_argument("-f", "--force", action="store_true", help="Overwrite without prompting")
     install_group = install_p.add_mutually_exclusive_group()

--- a/compiler/quilt/tools/main.py
+++ b/compiler/quilt/tools/main.py
@@ -112,12 +112,15 @@ def main():
     tag_remove_p.set_defaults(func=command.tag_remove)
 
     install_p = subparsers.add_parser("install")
+
+    # Require the "package" arg for "install" when default quilt yml file isn't present.
     if os.path.exists(DEFAULT_QUILT_YML):
         install_p.add_argument("package", type=str, help="owner/package_name[/path/...] or @filename",
                                nargs="?", default="@"+DEFAULT_QUILT_YML)
     else:
         install_p.add_argument("package", type=str, help="owner/package_name[/path/...] or @filename",
                                nargs="+")
+
     install_p.set_defaults(func=command.install)
     install_p.add_argument("-f", "--force", action="store_true", help="Overwrite without prompting")
     install_group = install_p.add_mutually_exclusive_group()

--- a/compiler/quilt/tools/main.py
+++ b/compiler/quilt/tools/main.py
@@ -118,8 +118,7 @@ def main():
         install_p.add_argument("package", type=str, help="owner/package_name[/path/...] or @filename",
                                nargs="?", default="@"+DEFAULT_QUILT_YML)
     else:
-        install_p.add_argument("package", type=str, help="owner/package_name[/path/...] or @filename",
-                               nargs="+")
+        install_p.add_argument("package", type=str, help="owner/package_name[/path/...] or @filename")
 
     install_p.set_defaults(func=command.install)
     install_p.add_argument("-f", "--force", action="store_true", help="Overwrite without prompting")


### PR DESCRIPTION
I've used an if/else line here, instead of the more complicated option of creating a custom argparse action.

I'm not certain, but I don't *think* there's a way to make an argument's `nargs` dependent on a function call using argparse itself without making a custom action.  Anyways, this is clean and clear.