### PR TITLE
command_test methods requiring input() mocking

### DIFF
--- a/compiler/quilt/test/test_command.py
+++ b/compiler/quilt/test/test_command.py
@@ -42,8 +42,6 @@ class CommandTest(QuiltTestCase):
             'https://foo.com',
             'http://foo.com',
             'https://foo.bar.net',
-#REVIEW: is this style of URL intentionally invalid?
-#            'https://foo.bar.net/baz',
             ]
         # test general URL setting -- result should match input
         for test_url in test_urls:
@@ -67,7 +65,6 @@ class CommandTest(QuiltTestCase):
             'foo.com',
             'ftp://foo.com',
             'blah://bar.com',
-#REVIEW: is this style of URL intentionally invalid?
             'http://foo.bar.com/baz',
             ]
         # test general URL setting -- result should match input


### PR DESCRIPTION
I was tasked with mocking tests in command_test that needed to mock input().  I wasn't, however, able to test install() in a reasonable amount of time.  I think it would take me a bit do do that, as it's quite long, and there are a few different code paths that would need to be mocked.

I mean, it could be done, but it seems that it might be better if install() were broken into smaller, more readily-testable chunks.  ..and in any case, it might take a bit more time than you'd really desire for me to spend on it.  ..although, that's up to you.

..meanwhile, here are the others.

__edit:__ Inaccurate PR title -- changed.