### PR TITLE
pytest now runs in parallel via pytest-xdist, uncovering state-leakage bugs in unittests

### DIFF
--- a/compiler/quilt/test/test_build.py
+++ b/compiler/quilt/test/test_build.py
@@ -168,20 +168,22 @@ class BuildTest(QuiltTestCase):
     def test_duplicates_conflict(self):
         mydir = os.path.dirname(__file__)
         path = os.path.join(mydir, 'dups_bad')
-        buildfilepath = os.path.join(path, 'build.yml')
+        buildfilename = 'build_test_duplicates_conflict.yml'
+        buildfilepath = os.path.join(path, buildfilename)
         if os.path.exists(buildfilepath):
             os.remove(buildfilepath)
 
         with self.assertRaises(build.BuildException):
-            build.generate_build_file(path)
+            build.generate_build_file(path, outfilename=buildfilename)
 
     def test_copy(self):
         mydir = os.path.dirname(__file__)
         path = os.path.join(mydir, 'data')
-        buildfilepath = os.path.join(path, 'build.yml')
+        buildfilename = 'build_test_copy.yml'
+        buildfilepath = os.path.join(path, buildfilename)
         assert not os.path.exists(buildfilepath), "%s already exists" % buildfilepath
 
-        command.build_from_path('test_copy/generated', path)
+        command.build_from_path('test_copy/generated', path, outfilename=buildfilename)
         from quilt.data.test_copy.generated import bad, foo, nuts
 
         assert not os.path.exists(buildfilepath), "%s should not have been created!" % buildfilepath

--- a/compiler/quilt/test/test_command.py
+++ b/compiler/quilt/test/test_command.py
@@ -264,9 +264,8 @@ class CommandTest(QuiltTestCase):
             with self.assertRaises(command.CommandException):
                 command.build('user/test', git_url)
 
-        from quilt.data.user import test
-        assert hasattr(test, 'foo')
-        assert isinstance(test.foo(), pd.DataFrame)
+        with self.assertRaises(ModuleNotFoundError):
+            from quilt.data.user import test
 
     def test_logging(self):
         mydir = os.path.dirname(__file__)

--- a/compiler/quilt/test/test_command.py
+++ b/compiler/quilt/test/test_command.py
@@ -262,10 +262,12 @@ class CommandTest(QuiltTestCase):
         
         with patch('subprocess.check_call', mock_git_clone):
             with self.assertRaises(command.CommandException):
-                command.build('user/test', git_url)
+                command.build('user/pkg__test_git_clone_fail', git_url)
 
-        with self.assertRaises(ModuleNotFoundError):
-            from quilt.data.user import test
+        # TODO: running -n (pytest-xdist) there's leaky state and can throw
+        # either ImportError: cannot import name or ModuleNotFoundError
+        with assertRaisesRegex(self, Exception, r'cannot import|not found'):
+            from quilt.data.user import pkg__test_git_clone_fail
 
     def test_logging(self):
         mydir = os.path.dirname(__file__)

--- a/compiler/quilt/test/test_command.py
+++ b/compiler/quilt/test/test_command.py
@@ -181,10 +181,11 @@ class CommandTest(QuiltTestCase):
     def test_generate_buildfile_wo_building(self):
         mydir = os.path.dirname(__file__)
         path = os.path.join(mydir, 'data')
-        buildfilepath = os.path.join(path, 'build.yml')
+        buildfilename = 'build_test_generate_buildfile_wo_building.yml'
+        buildfilepath = os.path.join(path, buildfilename)
         assert not os.path.exists(buildfilepath), "%s already exists" % buildfilepath
         try:
-            command.generate(path)
+            command.generate(path, outfilename=buildfilename)
             assert os.path.exists(buildfilepath), "failed to create %s" % buildfilepath
         finally:
             os.remove(buildfilepath)
@@ -266,7 +267,7 @@ class CommandTest(QuiltTestCase):
 
         # TODO: running -n (pytest-xdist) there's leaky state and can throw
         # either ImportError: cannot import name or ModuleNotFoundError
-        with assertRaisesRegex(self, Exception, r'cannot import|not found'):
+        with assertRaisesRegex(self, Exception, r'cannot import|not found|No module named'):
             from quilt.data.user import pkg__test_git_clone_fail
 
     def test_logging(self):

--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -312,13 +312,13 @@ def logout():
 
     _clear_session()
 
-def generate(directory):
+def generate(directory, outfilename=DEFAULT_BUILDFILE):
     """
     Generate a build-file for quilt build from a directory of
     source files.
     """
     try:
-        buildfilepath = generate_build_file(directory)
+        buildfilepath = generate_build_file(directory, outfilename=outfilename)
     except BuildException as builderror:
         raise CommandException(str(builderror))
 
@@ -469,7 +469,7 @@ def build_from_node(package, node):
     _process_node(node)
     package_obj.save_contents()
 
-def build_from_path(package, path, dry_run=False, env='default'):
+def build_from_path(package, path, dry_run=False, env='default', outfilename=DEFAULT_BUILDFILE):
     """
     Compile a Quilt data package from a build file.
     Path can be a directory, in which case the build file will be generated automatically.
@@ -481,13 +481,13 @@ def build_from_path(package, path, dry_run=False, env='default'):
 
     try:
         if os.path.isdir(path):
-            buildpath = os.path.join(path, DEFAULT_BUILDFILE)
+            buildpath = os.path.join(path, outfilename)
             if os.path.exists(buildpath):
                 raise CommandException(
                     "Build file already exists. Run `quilt build %r` instead." % buildpath
                 )
 
-            contents = generate_contents(path, DEFAULT_BUILDFILE)
+            contents = generate_contents(path, outfilename)
             build_package_from_contents(owner, pkg, path, contents, dry_run=dry_run, env=env)
         else:
             build_package(owner, pkg, path, dry_run=dry_run, env=env)


### PR DESCRIPTION
Given prev issues with state leakage in the unittests, I had a correct hunch that pytest-xdist (parallel pytest) might uncover more issues.  Sure enough it did!

But even better, xdist actually works!

Obviously, YMMV based on hardware and other stuff running but on my mac, I'm seeing:
   pytest -n 1  ==> 39 sec
   pytest -n 6 ==> 15 sec   (no more improvement after ~n=6)

To install pytest-xdist, simply run: pip install pytest-xdist
