### PR TITLE
Add support for building empty packages, empty groups, refactor pandas kwargs

### DIFF
--- a/compiler/quilt/test/build.yml
+++ b/compiler/quilt/test/build.yml
@@ -10,7 +10,8 @@ contents:
     xls:
       file: data/10KRows13Cols.xlsx
     xls_skip:
-      skiprows: [0,10,100]
+      kwargs:
+        skiprows: [0,10,100]
       file: data/10KRows13Cols.xlsx
   README:
     file: data/README.md

--- a/compiler/quilt/test/build_empty.yml
+++ b/compiler/quilt/test/build_empty.yml
@@ -1,0 +1,1 @@
+contents: {}

--- a/compiler/quilt/test/build_group_args.yml
+++ b/compiler/quilt/test/build_group_args.yml
@@ -23,7 +23,8 @@ contents:
     subgroup:
       # transform and skiprows apply to all children, unless overidden
       transform: tsv
-      skiprows: 1
+      kwargs:
+        skiprows: 1
       tsv:
         # should be tsv
         file: data/tsv.txt
@@ -41,5 +42,8 @@ contents:
           file: data/tsv.txt
         three:
           file: data/tsv.txt
+  group_empty:
+  group_x:
+    empty_child:
 ...
 

--- a/compiler/quilt/test/build_group_args.yml
+++ b/compiler/quilt/test/build_group_args.yml
@@ -34,7 +34,7 @@ contents:
         transform: id
         file: data/csv.txt
       many_tsv:
-        # all of the following should inherit transform: csv
+        # all of the following should inherit transform: tsv
         one:
           file: data/tsv.txt
         two:

--- a/compiler/quilt/test/test_build.py
+++ b/compiler/quilt/test/test_build.py
@@ -101,6 +101,17 @@ class BuildTest(QuiltTestCase):
             'Expected column of ints with nulls to deserialize as numeric'
         # TODO add more integrity checks, incl. negative test cases
 
+    def test_build_empty(self):
+        """
+        test building from build_empty.yml
+        """
+        mydir = os.path.dirname(__file__)
+        path = os.path.join(mydir, './build_empty.yml')
+        build.build_package('empty', 'pkg', path)
+
+        from quilt.data.empty import pkg
+        assert not pkg._keys(), 'Expected package to be empty'
+
     def test_build_group_args(self):
         """
         test building from build_group_args.yml

--- a/compiler/quilt/test/test_build.py
+++ b/compiler/quilt/test/test_build.py
@@ -122,9 +122,9 @@ class BuildTest(QuiltTestCase):
 
         from quilt.data.groups import pkg
         
-        assert type(pkg.group_a.csv()) is DataFrame, \
+        assert isinstance(pkg.group_a.csv(), DataFrame), \
             'Expected parent `transform: csv` to affect group_a.csv()'
-        assert type(pkg.group_a.tsv()) is DataFrame, \
+        assert isinstance(pkg.group_a.tsv(), DataFrame), \
             'Expected local `transform: tsv` to affect group_a.tsv()'
         # TODO these tests should really test the node type and verify it as a file node
         # but currently both raw files and DFs are DataNode instances
@@ -133,7 +133,7 @@ class BuildTest(QuiltTestCase):
         assert isinstance(pkg.group_b.subgroup.txt(), string_types), \
             'Expected `transform: id` to be inferred from file extension'
         # ENDTODO
-        assert type(pkg.group_b.tsv()) is DataFrame, \
+        assert isinstance(pkg.group_b.tsv(), DataFrame), \
             'Expected `transform: tsv` to be inferred from file extension'
         assert pkg.group_b.subgroup.tsv().shape == (1, 3), \
             'Expected `transform: tsv` and one skipped row from group args'
@@ -141,9 +141,9 @@ class BuildTest(QuiltTestCase):
             'Expected local `transform: csv` and one skipped row from group args'
         assert pkg.group_b.subgroup.many_tsv.one().shape == (1, 3), \
             'Expected local `transform: csv` and one skipped row from group args'
-        assert type(pkg.group_b.subgroup.many_tsv.two()) is DataFrame, \
+        assert isinstance(pkg.group_b.subgroup.many_tsv.two(), DataFrame), \
             'Expected `transform: tsv` from ancestor' 
-        assert type(pkg.group_b.subgroup.many_tsv.three()) is DataFrame, \
+        assert isinstance(pkg.group_b.subgroup.many_tsv.three(), DataFrame), \
             'Expected `transform: tsv` from ancestor' 
         assert not pkg.group_empty._keys(), 'Expected group_empty to be empty'
         assert not pkg.group_x.empty_child._keys(), 'Expected group_x.emptychild to be empty'

--- a/compiler/quilt/test/test_build.py
+++ b/compiler/quilt/test/test_build.py
@@ -145,6 +145,8 @@ class BuildTest(QuiltTestCase):
             'Expected `transform: tsv` from ancestor' 
         assert type(pkg.group_b.subgroup.many_tsv.three()) is DataFrame, \
             'Expected `transform: tsv` from ancestor' 
+        assert not pkg.group_empty._keys(), 'Expected group_empty to be empty'
+        assert not pkg.group_x.empty_child._keys(), 'Expected group_x.emptychild to be empty'
 
     def test_build_hdf5(self):
         mydir = os.path.dirname(__file__)

--- a/compiler/quilt/tools/build.py
+++ b/compiler/quilt/tools/build.py
@@ -118,8 +118,7 @@ def _build_node(build_dir, package, name, node, fmt, target='pandas', checks_con
         # handle group leaf nodes (empty groups)
         if not node:
             if not dry_run:
-                if name: # an empty package is not a group
-                    package.save_group(name)
+                package.save_group(name)
             return
         # handle remaining leaf nodes types
         rel_path = node.get(RESERVED['file'])

--- a/compiler/quilt/tools/build.py
+++ b/compiler/quilt/tools/build.py
@@ -51,13 +51,8 @@ def _path_hash(path, transform, kwargs):
     return digest_string(srcinfo)
 
 def _is_internal_node(node):
-    return not _is_leaf_node(node)
-
-def _is_leaf_node(node):
-    """
-    A leaf node either has no children or defines a `file` key
-    """
-    return not node or node.get(RESERVED['file'])
+    is_leaf = not node or node.get(RESERVED['file'])
+    return not is_leaf 
 
 def _pythonize_name(name):
     safename = re.sub('[^A-Za-z0-9]+', '_', name).strip('_')

--- a/compiler/quilt/tools/const.py
+++ b/compiler/quilt/tools/const.py
@@ -9,6 +9,7 @@ class TargetType(Enum):
     """
     PANDAS = 'pandas'
     FILE = 'file'
+    GROUP = 'group'
 
 DATEF = '%Y-%m-%d'
 TIMEF = '%H:%M:%S'
@@ -20,9 +21,10 @@ DEFAULT_QUILT_YML = 'quilt.yml'
 
 # reserved words in build.yml
 RESERVED = {
-    'file': 'file',
     'checks': 'checks',
     'environments': 'environments',
+    'file': 'file',
+    'kwargs': 'kwargs',
     'transform': 'transform'
 }
 

--- a/compiler/quilt/tools/package.py
+++ b/compiler/quilt/tools/package.py
@@ -226,6 +226,14 @@ class Package(object):
         if not os.path.exists(objpath):
             copyfile(srcfile, objpath)
 
+    def save_group(self, name):
+        """
+        Save a (raw) file to the store.
+        """
+        fullname = name.lstrip('/').replace('/', '.')
+        if fullname:
+            self._add_to_contents(fullname, None, '', None, 'group', None)
+
     def get_contents(self):
         """
         Returns a dictionary with the contents of the package.
@@ -341,7 +349,7 @@ class Package(object):
 
     def _add_to_contents(self, fullname, hashes, ext, path, target, fmt):
         """
-        Adds an object (name-hash mapping) to the package's contents.
+        Adds an object (name-hash mapping) or group to package contents.
         """
         contents = self.get_contents()
         ipath = fullname.split('.')
@@ -359,7 +367,9 @@ class Package(object):
 
         try:
             target_type = TargetType(target)
-            if target_type is TargetType.PANDAS:
+            if target_type is TargetType.GROUP:
+                node = GroupNode(dict())
+            elif target_type is TargetType.PANDAS:
                 assert fmt is not None
                 node = TableNode(
                     hashes=hashes,

--- a/compiler/quilt/tools/package.py
+++ b/compiler/quilt/tools/package.py
@@ -233,7 +233,7 @@ class Package(object):
 
     def save_group(self, name):
         """
-        Save a (raw) file to the store.
+        Save a group to the store.
         """
         fullname = name.lstrip('/').replace('/', '.')
         if fullname:


### PR DESCRIPTION
* Added reserved word `kwargs` which is where all panadas/handler args should go (eliminates ambiguity between pandas kwargs and groups)