### PR TITLE
Display the overwrite prompt before looking up tags and versions

### DIFF
--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -826,6 +826,12 @@ def install(package, hash=None, version=None, tag=None, force=False):
     store = PackageStore()
     existing_pkg = store.get_package(owner, pkg)
 
+    if existing_pkg is not None and not force:
+        print("{owner}/{pkg} already installed.".format(owner=owner, pkg=pkg))
+        overwrite = input("Overwrite? (y/n) ")
+        if overwrite.lower() != 'y':
+            return
+
     if version is not None:
         response = session.get(
             "{url}/api/version/{owner}/{pkg}/{version}".format(
@@ -862,12 +868,6 @@ def install(package, hash=None, version=None, tag=None, force=False):
         )
     )
     assert response.ok # other responses handled by _handle_response
-
-    if existing_pkg is not None and not force:
-        print("{owner}/{pkg} already installed.".format(owner=owner, pkg=pkg))
-        overwrite = input("Overwrite? (y/n) ")
-        if overwrite.lower() != 'y':
-            return
 
     dataset = response.json(object_hook=decode_node)
     response_urls = dataset['urls']


### PR DESCRIPTION
Prompt early, before doing unnecessary network I/O.