### PR TITLE
better import error message

### DIFF
--- a/compiler/quilt/data.py
+++ b/compiler/quilt/data.py
@@ -112,12 +112,20 @@ class ModuleFinder(object):
                 file_path = store.user_path(parts[0])
                 if os.path.isdir(file_path):
                     return FakeLoader(file_path)
+                else:
+                    raise ImportError('Could not find any installed packages by user {user!r}.\n  '
+                                      'Check the name, or use "quilt install {user}/<packagename>" to install'
+                                      .format(user=parts[0]))
         elif len(parts) == 2:
             user, package = parts
             pkgobj = PackageStore.find_package(user, package)
             if pkgobj:
                 file_path = pkgobj.get_path()
                 return PackageLoader(file_path, pkgobj)
+            else:
+                raise ImportError('Could not find package by user {user!r} named {package!r}.\n  '
+                                  'Check the name, or use "quilt install {user}/{package}" to install'
+                                  .format(**locals()))
 
         return None
 

--- a/compiler/quilt/test/test_command.py
+++ b/compiler/quilt/test/test_command.py
@@ -382,7 +382,7 @@ class CommandTest(QuiltTestCase):
 
         # TODO: running -n (pytest-xdist) there's leaky state and can throw
         # either ImportError: cannot import name or ModuleNotFoundError
-        with assertRaisesRegex(self, Exception, r'cannot import|not found|No module named'):
+        with assertRaisesRegex(self, Exception, r'cannot import|not found|No module named|Could not find'):
             from quilt.data.user import pkg__test_git_clone_fail
 
     def test_logging(self):


### PR DESCRIPTION
Improves the ImportError message when importing a data package:

```
# when username has no installed packages
[1]: from quilt.data.akarvex import bop
ImportError: Could not find any installed packages by user 'akarvex'.
  Check the name, or use "quilt install akarvex/<packagename>" to install

# username has some installed packages, but not the specified package
[2]: from quilt.data.akarve import bop
ImportError: Could not find package by user 'akarve' named 'bop'.
  Check the name, or use "quilt install akarve/bop" to install
```

..note that in the first case, the package name isn't available at import time, as the parent module is imported (and fails) first.

Naturally, this also works when importing via other methods, such as when using `importlib`. 