### PR TITLE
Fix ambiguous hashes

### DIFF
--- a/compiler/quilt/test/test_command.py
+++ b/compiler/quilt/test/test_command.py
@@ -131,9 +131,9 @@ class CommandTest(QuiltTestCase):
             registry_url + "/api/log/user/test/",
             json=fake_data
         )
-        # Data will be reversed in _match_hash, so we need to reverse our data here, too
-        fake_data_ambiguous = [entry['hash'] for entry in reversed(fake_data['logs'])
-                               if entry['hash'].startswith(ambiguous_token)]
+        # Ambiguous hashes in _match_hash's exception will be sorted -- sorted here to match.
+        fake_data_ambiguous = sorted(entry['hash'] for entry in fake_data['logs']
+                               if entry['hash'].startswith(ambiguous_token))
         fake_data_regexp = '[\s\S]'.join(fake_data_ambiguous)
         with assertRaisesRegex(self, command.CommandException, fake_data_regexp):
             command._match_hash(session, owner='user', pkg='test', hash='795a7b')

--- a/compiler/quilt/test/test_command.py
+++ b/compiler/quilt/test/test_command.py
@@ -134,7 +134,9 @@ class CommandTest(QuiltTestCase):
         # Ambiguous hashes in _match_hash's exception will be sorted -- sorted here to match.
         fake_data_ambiguous = sorted(entry['hash'] for entry in fake_data['logs']
                                if entry['hash'].startswith(ambiguous_token))
-        fake_data_regexp = '[\s\S]'.join(fake_data_ambiguous)
+        # this will match each ambiguous hash, in order, separated by anything.
+        # ..it allows for formatting changes in the error, but requires the same order.
+        fake_data_regexp = '[\s\S]+'.join(fake_data_ambiguous)
         with assertRaisesRegex(self, command.CommandException, fake_data_regexp):
             command._match_hash(session, owner='user', pkg='test', hash='795a7b')
 

--- a/compiler/quilt/test/test_command.py
+++ b/compiler/quilt/test/test_command.py
@@ -136,7 +136,7 @@ class CommandTest(QuiltTestCase):
                                if entry['hash'].startswith(ambiguous_token))
         # this will match each ambiguous hash, in order, separated by anything.
         # ..it allows for formatting changes in the error, but requires the same order.
-        fake_data_regexp = '[\s\S]+'.join(fake_data_ambiguous)
+        fake_data_regexp = r'(.|\n)+'.join(fake_data_ambiguous)
         with assertRaisesRegex(self, command.CommandException, fake_data_regexp):
             command._match_hash(session, owner='user', pkg='test', hash='795a7b')
 

--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -249,6 +249,12 @@ def _open_url(url):
 
 def _match_hash(session, owner, pkg, hash, raise_exception=True):
     hash = hash.lower()
+
+    if not (6 <= len(hash) <= 64):
+        raise CommandException('Invalid hash of length {}: {!r}\n  '
+                               'Ensure that the hash is between 6 and 64 characters.'
+                               .format(len(hash), hash))
+
     # short-circuit for exact length
     if len(hash) == 64:
         return hash

--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -261,14 +261,14 @@ def _match_hash(session, owner, pkg, hash, raise_exception=True):
         )
     )
 
-    logs = reversed(response.json()['logs'])
-    matches = [entry for entry in logs if entry['hash'].startswith(hash)]
+    matches = set(entry['hash'] for entry in response.json()['logs']
+                  if entry['hash'].startswith(hash))
 
     if len(matches) == 1:
-        return matches[0]['hash']
+        return matches.pop()
     if len(matches) > 1:
-        ambiguous = [entry['hash'] for entry in matches]
-        ambiguous = '\n'.join(ambiguous)
+        # Sorting for consistency in testing, as well as visual comparison of hashes
+        ambiguous = '\n'.join(sorted(matches))
         raise CommandException(
             "Ambiguous hash for package {owner}/{pkg}: {hash!r} matches the folowing hashes:\n\n{ambiguous}"
             .format(**locals()))

--- a/compiler/quilt/tools/command.py
+++ b/compiler/quilt/tools/command.py
@@ -247,7 +247,7 @@ def _open_url(url):
     except Exception as ex:     # pylint:disable=W0703
         print("Failed to launch the browser: %s" % ex)
 
-def _match_hash(session, owner, pkg, hash, raise_exception=True):
+def _match_hash(session, owner, pkg, hash):
     hash = hash.lower()
 
     if not (6 <= len(hash) <= 64):
@@ -278,9 +278,7 @@ def _match_hash(session, owner, pkg, hash, raise_exception=True):
         raise CommandException(
             "Ambiguous hash for package {owner}/{pkg}: {hash!r} matches the folowing hashes:\n\n{ambiguous}"
             .format(**locals()))
-    if raise_exception:
-        raise CommandException("Invalid hash for package {owner}/{pkg}: {hash}".format(**locals()))
-    return None
+    raise CommandException("Invalid hash for package {owner}/{pkg}: {hash}".format(**locals()))
 
 
 def login():

--- a/compiler/quilt/tools/main.py
+++ b/compiler/quilt/tools/main.py
@@ -52,11 +52,6 @@ def main():
     """
     Build and run parser
     """
-    def check_hash(group, hashstr):
-        # TODO: add this universally once short hashes are supported in other functions.
-        return (hashstr if 6 <= len(hashstr) <= 64 else
-                group.error('hashes must be 6-64 chars long'))
-
     parser = CustomHelpParser(description="Quilt Command Line", add_help=False, full_help_only=True)
     parser.add_argument('--version', action='version', version=get_full_version(), help="Show version number and exit")
 
@@ -152,8 +147,7 @@ def main():
     install_p.set_defaults(func=command.install)
     install_p.add_argument("-f", "--force", action="store_true", help="Overwrite without prompting")
     install_group = install_p.add_mutually_exclusive_group()
-    install_group.add_argument("-x", "--hash", help="Package hash",
-                               type=lambda val: check_hash(install_p, val))
+    install_group.add_argument("-x", "--hash", help="Package hash", type=str)
     install_group.add_argument("-v", "--version", type=str, help="Package version")
     install_group.add_argument("-t", "--tag", type=str, help="Package tag - defaults to 'latest'")
 


### PR DESCRIPTION
As long as _match_hash is used, ambiguous hashes will raise a CommandException:

```
$ quilt install example/foo 391e01
Ambiguous hash for package example/foo: 'd91e01' matches the folowing hashes:

d91e01b0cffde1e3c987262620e0050f4377ac55cd000f77b37bae82462e2acd
d91e0143a9e0367b92a8f67b1ce8417adb5b64a5d7df1d0664ad6bd1b94c4b99
```

The server sometimes returns duplicate hashes, which aren't considered ambiguous, even though they both start with the same short-hash string.