### PR TITLE
QfTF/vfs: DEFAULT_MODULE_MAPPINGS missing module/callable culling

### DIFF
--- a/compiler/quilt/vfs.py
+++ b/compiler/quilt/vfs.py
@@ -7,7 +7,7 @@
     ...
     1. Title: Iris Plants Database
     	Updated Sept 21 by C.Blake - Added discrepency information
-    
+
     2. Sourc
     >>> print(open('foo/bar/iris_names').read()[0:100])
     Traceback (most recent call last):
@@ -23,7 +23,7 @@
     >>> print(open('foo/bar/iris_names').read()[0:100])
     1. Title: Iris Plants Database
     	Updated Sept 21 by C.Blake - Added discrepency information
-    
+
     2. Sourc
     >>> quilt.vfs.teardown(patchers)
     >>> print(open('foo/bar/iris_names').read()[0:100])
@@ -64,142 +64,16 @@
 
 
 """
-
-# ---------------------------------------------------------------------------
-# START DUPLICATE CODE
-# ---------------------------------------------------------------------------
-# TODO: copied from data.py -- pls share code!
-
-"""
-Magic module that maps its submodules to Quilt tables.
-
-Submodules have the following format: quilt.data.$user.$package.$table
-
-E.g.:
-  import quilt.data.$user.$package as $package
-  print $package.$table
-or
-  from quilt.data.$user.$package import $table
-  print $table
-
-The corresponding data is looked up in `quilt_modules/$user/$package.json`
-in ancestors of the current directory.
-"""
-
-import imp
 import os.path
-import sys
 import string
-
-from six import iteritems
 import importlib
 from contextlib import contextmanager
 
-from .nodes import DataNode, GroupNode, PackageNode
-from .tools import core, command
-from .tools.store import PackageStore, parse_package
 
-__path__ = []  # Required for submodules to work
+from .nodes import GroupNode
+from .tools import command
+from .tools.store import parse_package
 
-
-class FakeLoader(object):
-    """
-    Fake module loader used to create intermediate user and package modules.
-    """
-    def __init__(self, path):
-        self._path = path
-
-    def load_module(self, fullname):
-        """
-        Returns an empty module.
-        """
-        mod = sys.modules.setdefault(fullname, imp.new_module(fullname))
-        mod.__file__ = self._path
-        mod.__loader__ = self
-        mod.__path__ = []
-        mod.__package__ = fullname
-        return mod
-
-
-def _from_core_node(package, core_node):
-    if isinstance(core_node, core.TableNode) or isinstance(core_node, core.FileNode):
-        node = DataNode(package, core_node)
-    else:
-        if isinstance(core_node, core.RootNode):
-            node = PackageNode(package, core_node)
-        elif isinstance(core_node, core.GroupNode):
-            node = GroupNode(package, core_node)
-        else:
-            assert "Unexpected node: %r" % core_node
-
-        for name, core_child in iteritems(core_node.children):
-            child = _from_core_node(package, core_child)
-            setattr(node, name, child)
-
-    return node
-
-
-class PackageLoader(object):
-    """
-    Module loader for Quilt tables.
-    """
-    def __init__(self, path, package):
-        self._path = path
-        self._package = package
-
-    def load_module(self, fullname):
-        """
-        Returns an object that lazily looks up tables and groups.
-        """
-        mod = sys.modules.get(fullname)
-        if mod is not None:
-            return mod
-
-        # We're creating an object rather than a module. It's a hack, but it's approved by Guido:
-        # https://mail.python.org/pipermail/python-ideas/2012-May/014969.html
-
-        mod = _from_core_node(self._package, self._package.get_contents())
-        sys.modules[fullname] = mod
-        return mod
-
-
-class ModuleFinder(object):
-    """
-    Looks up submodules.
-    """
-    @staticmethod
-    def find_module(fullname, path=None):
-        """
-        Looks up the table based on the module path.
-        """
-        if not fullname.startswith(__name__ + '.'):
-            # Not a quilt submodule.
-            return None
-
-        submodule = fullname[len(__name__) + 1:]
-        parts = submodule.split('.')
-
-        if len(parts) == 1:
-            for store_dir in PackageStore.find_store_dirs():
-                store = PackageStore(store_dir)
-                # find contents
-                file_path = store.user_path(parts[0])
-                if os.path.isdir(file_path):
-                    return FakeLoader(file_path)
-        elif len(parts) == 2:
-            user, package = parts
-            pkgobj = PackageStore.find_package(user, package)
-            if pkgobj:
-                file_path = pkgobj.get_path()
-                return PackageLoader(file_path, pkgobj)
-
-        return None
-
-sys.meta_path.append(ModuleFinder)
-
-# ---------------------------------------------------------------------------
-# END DUPLICATE CODE
-# ---------------------------------------------------------------------------
 
 def filepatch(module_name, func_name, action_func):
     """monkeypatch an open-like function (that takes a filename as the first argument)
@@ -351,7 +225,7 @@ def setup(pkg, hash=None, version=None, tag=None, force=False,
          quilt.vfs.teardown(patchers)
 
        if you like, you can wrap the calls, which is similar to the context-version above
-         
+
          patchers = quilt.vfs.setup('uciml/iris', mappings={'foo/bar':'raw'})
          try:
              open('foo/bar/iris_names')
@@ -367,4 +241,3 @@ def setup(pkg, hash=None, version=None, tag=None, force=False,
 def teardown(patchers):
     for patcher in patchers:
         patcher.stop()
-

--- a/compiler/quilt/vfs.py
+++ b/compiler/quilt/vfs.py
@@ -107,7 +107,6 @@ def filepatch(module_name, func_name, action_func):
     return patcher
 
 
-# Note: To test this, uninstall h5py, then run your quilt_vfs_test.py.
 def scrub_patchmap(patchmap, verbose=False, strict=False):
     """Return a version of patchmap with missing modules/callables removed.
 
@@ -125,13 +124,13 @@ def scrub_patchmap(patchmap, verbose=False, strict=False):
             continue
         if not hasattr(module, funcname):
             if verbose:
-                print("Dropped {}.{} from the patch map (func/class not present)")
+                print("Dropped {}.{} from the patch map (func/class not present)".format(module, funcname))
             if strict:
                 raise AttributeError("{} is missing from module {}".format(funcname, modname))
             continue
         if not callable(getattr(module, funcname)):
             if verbose:
-                print("Dropped {}.{} from the patch map (not callable)")
+                print("Dropped {}.{} from the patch map (not callable)".format(module, funcname))
             if strict:
                 raise TypeError("{}.{} is not callable".format(funcname, modname))
             continue
@@ -161,17 +160,12 @@ def make_mapfunc(pkg, hash=None, version=None, tag=None, force=False,
     """core support for mapping filepaths to objects in quilt local objs/ datastore.
        TODO: add support for reading/iterating directories, e.g. os.scandir() and friends
     """
-#XXX: Unused
-    # if len(kwargs) == 0:
-    #     kwargs = DEFAULT_MODULE_MAPPINGS
     if install:
         command.install(pkg, hash=hash, version=version, tag=tag, force=force)
     owner, pkg = parse_package(pkg)
 
     if mappings is None:
         mappings = { ".": "" }  # TODO: test this case
-#XXX: Unused/debug
-#    pkgname = "quilt.data."+owner+"."+pkg
 
     if not callable(charmap):
         fromstr = tostr = ""


### PR DESCRIPTION
Ok, right now (since we're working on TF/vfs) the function is set to be verbose and comment about everything it removes from the default module mappings list.  It does the following:

* checks that the module is importable
* checks that the specified function/class exists
* checks that the specified function/class is callable

..rejects anything that doesn't fit, returns a culled list.